### PR TITLE
Test stage 11: (reference-mode) trigger other actions within the same store.

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -327,7 +327,7 @@ test('stage 9: immutable reference ', () => {
 	expect(get(profile)).toEqual({ name: 'John', age: 35 });
 });
 
-test('stage 10: trigger other actions within the same store', () => {
+test('stage 10: (primitive-mode) trigger other actions within the same store', () => {
 	interface Count {
 		$init: number;
 		increase: () => void;
@@ -347,7 +347,7 @@ test('stage 10: trigger other actions within the same store', () => {
 	});
 
 	const unsubscribe = count.subscribe((value) => {
-		console.log('stage 10: trigger other actions within the same store', value);
+		console.log('stage 10: (primitive-mode) trigger other actions within the same store', value);
 	});
 
 	count.increase();
@@ -357,6 +357,41 @@ test('stage 10: trigger other actions within the same store', () => {
 	count.double();
 
 	expect(get(count)).toBe(3);
+
+	unsubscribe();
+});
+
+test('stage 11: (reference-mode) trigger other actions within the same store', () => {
+	interface Profile {
+		name: string;
+		changeName: (name: string) => void;
+		changeNameIfJohn: (name: string) => void;
+	}
+
+	const profile = ex<Profile>({
+		$name: 'count-test-store',
+		name: '',
+		changeName(name: string) {
+			this.name = name;
+		},
+		changeNameIfJohn(name: string) {
+			if (this.name === 'John') {
+				this.changeName(name);
+			}
+		}
+	});
+
+	const unsubscribe = profile.subscribe((value) => {
+		console.log('stage 11: (reference-mode) trigger other actions within the same store', value);
+	});
+
+	profile.changeName('John');
+
+	expect(get(profile).name).toBe('John');
+
+	profile.changeNameIfJohn('Not John');
+
+	expect(get(profile).name).toBe('Not John');
 
 	unsubscribe();
 });

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -105,8 +105,10 @@ export function ex<State>(slice: ExSlice<State>) {
 						}
 						return bindState.$init;
 					} else {
-						fn.apply(prev, args);
-						return prev;
+						const bindState = { ...(prev as OnlyState<State>), ...getActionsFromSlice(slice) };
+						fn.apply(bindState, args);
+						const onlyState = getOnlyStateFormSlice(bindState);
+						return onlyState;
 					}
 				});
 			}


### PR DESCRIPTION
Parent: #70 
[Bug 146](https://dev.azure.com/nonpanpila/svelte-exstore/_workitems/edit/146): Stage 11: (reference-mode) trigger other actions within the same store.

#### This should work.
```ts
const profile = ex<Profile>({
    $name: 'count-test-store',
    name: '',
    changeName(name: string) {
	this.name = name;
    },
    changeNameIfJohn(name: string) {
	if (this.name === 'John') {
            this.changeName(name);
	}
    }
});
```